### PR TITLE
Revert "Bump axios from 1.13.2 to 1.13.5 in /selenium-nightwatch"

### DIFF
--- a/selenium-nightwatch/package-lock.json
+++ b/selenium-nightwatch/package-lock.json
@@ -793,13 +793,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
+      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },


### PR DESCRIPTION
Reverts GoogleChromeLabs/chromedriver-bug-repro-templates#22